### PR TITLE
deprecate gplus but still use jwt 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ All notable changes to this project will be documented in this file.
 ### Removed
 - Support for JWT 1.x.
 - Support for `raw_friend_info` and `raw_image_info`.
-- Stop using Google+ API endpoints.
 
 ### Fixed
 - Nothing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-## 0.6.0 - 2018-12-28
-
-### Added
-- Support for JWT 2.x.
-
-### Deprecated
-- Nothing.
-
-### Removed
-- Support for JWT 1.x.
-- Support for `raw_friend_info` and `raw_image_info`.
-
-### Fixed
-- Nothing.
-
 ## 0.5.4 - 2018-12-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ You can configure several options, which you pass in to the `provider` method vi
 
 * `openid_realm`: Set the OpenID realm value, to allow upgrading from OpenID based authentication to OAuth 2 based authentication. When this is set correctly an `openid_id` value will be set in `[:extra][:id_info]` in the authentication hash with the value of the user's OpenID ID URL.
 
+* `verify_iss`: Allows you to disable iss validation when decoding the JWT. This was added since Google now returns either `accounts.google.com` or `https://accounts.google.com`, and there is no way to predict what they will return, causing JWT validation failures.
+
 Here's an example of a possible configuration where the strategy name is changed, the user is asked for extra permissions, the user is always prompted to select his account when logging in and the user's profile picture is returned as a thumbnail:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ OmniAuth.config.full_host = Rails.env.production? ? 'https://domain.com' : 'http
 
 ## License
 
-Copyright (c) 2018 by Josh Ellithorpe
+Copyright (c) 2017 by Josh Ellithorpe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/examples/Gemfile
+++ b/examples/Gemfile
@@ -2,6 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'omniauth-google-oauth2', '~> 0.6'
+gem 'omniauth-google-oauth2', '~> 0.5'
 gem 'rubocop'
 gem 'sinatra', '~> 1.4'

--- a/lib/omniauth/google_oauth2/version.rb
+++ b/lib/omniauth/google_oauth2/version.rb
@@ -2,6 +2,6 @@
 
 module OmniAuth
   module GoogleOauth2
-    VERSION = '0.6.0'
+    VERSION = '0.5.4'
   end
 end

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -8,7 +8,6 @@ module OmniAuth
   module Strategies
     # Main class for Google OAuth2 strategy.
     class GoogleOauth2 < OmniAuth::Strategies::OAuth2
-      ALLOWED_ISSUERS = ['accounts.google.com', 'https://accounts.google.com'].freeze
       BASE_SCOPE_URL = 'https://www.googleapis.com/auth/'
       BASE_SCOPES = %w[profile email openid].freeze
       DEFAULT_SCOPE = 'email,profile'
@@ -21,6 +20,7 @@ module OmniAuth
       option :jwt_leeway, 60
       option :authorize_options, %i[access_type hd login_hint prompt request_visible_actions scope state redirect_uri include_granted_scopes openid_realm device_id device_name]
       option :authorized_client_ids, []
+      option :verify_iss, true
 
       option :client_options,
              site: 'https://oauth2.googleapis.com',
@@ -60,23 +60,18 @@ module OmniAuth
         hash = {}
         hash[:id_token] = access_token['id_token']
         if !options[:skip_jwt] && !access_token['id_token'].nil?
-          decoded = ::JWT.decode(access_token['id_token'], nil, false).first
-
-          # We have to manually verify the claims because the third parameter to
-          # JWT.decode is false since no verification key is provided.
-          ::JWT::Verify.verify_claims(decoded,
-                                      verify_iss: true,
-                                      iss: ALLOWED_ISSUERS,
-                                      verify_aud: true,
-                                      aud: options.client_id,
-                                      verify_sub: false,
-                                      verify_expiration: true,
-                                      verify_not_before: true,
-                                      verify_iat: true,
-                                      verify_jti: false,
-                                      leeway: options[:jwt_leeway])
-
-          hash[:id_info] = decoded
+          hash[:id_info] = ::JWT.decode(
+            access_token['id_token'], nil, false, verify_iss: options.verify_iss,
+                                                  iss: 'accounts.google.com',
+                                                  verify_aud: true,
+                                                  aud: options.client_id,
+                                                  verify_sub: false,
+                                                  verify_expiration: true,
+                                                  verify_not_before: true,
+                                                  verify_iat: true,
+                                                  verify_jti: false,
+                                                  leeway: options[:jwt_leeway]
+          ).first
         end
         hash[:raw_info] = raw_info unless skip_info?
         prune! hash

--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -12,7 +12,7 @@ module OmniAuth
       BASE_SCOPE_URL = 'https://www.googleapis.com/auth/'
       BASE_SCOPES = %w[profile email openid].freeze
       DEFAULT_SCOPE = 'email,profile'
-      USER_INFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'
+      USER_INFO_URL = 'https://www.googleapis.com/oauth2/v3/userinfo'.freeze
 
       option :name, 'google_oauth2'
       option :skip_friends, true

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency 'jwt', '>= 2.0'
+  gem.add_runtime_dependency 'jwt', '>= 1.5'
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.5'
 

--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -313,60 +313,35 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     before { allow(subject).to receive(:access_token).and_return(access_token) }
 
     describe 'id_token' do
-      shared_examples 'id_token issued by valid issuer' do |issuer| # rubocop:disable Metrics/BlockLength
-        context 'when the id_token is passed into the access token' do
-          let(:token_info) do
-            {
-              'abc' => 'xyz',
-              'exp' => Time.now.to_i + 3600,
-              'nbf' => Time.now.to_i - 60,
-              'iat' => Time.now.to_i,
-              'aud' => 'appid',
-              'iss' => issuer
-            }
-          end
-          let(:id_token) { JWT.encode(token_info, 'secret') }
-          let(:access_token) { OAuth2::AccessToken.from_hash(client, 'id_token' => id_token) }
-
-          it 'should include id_token when set on the access_token' do
-            expect(subject.extra).to include(id_token: id_token)
-          end
-
-          it 'should include id_info when id_token is set on the access_token and skip_jwt is false' do
-            subject.options[:skip_jwt] = false
-            expect(subject.extra).to include(id_info: token_info)
-          end
-
-          it 'should not include id_info when id_token is set on the access_token and skip_jwt is true' do
-            subject.options[:skip_jwt] = true
-            expect(subject.extra).not_to have_key(:id_info)
-          end
-
-          it 'should include id_info when id_token is set on the access_token by default' do
-            expect(subject.extra).to include(id_info: token_info)
-          end
-        end
-      end
-
-      it_behaves_like 'id_token issued by valid issuer', 'accounts.google.com'
-      it_behaves_like 'id_token issued by valid issuer', 'https://accounts.google.com'
-
-      context 'when the id_token is issued by an invalid issuer' do
-        let(:token_info) do
+      context 'when the id_token is passed into the access token' do
+        token_info =
           {
             'abc' => 'xyz',
             'exp' => Time.now.to_i + 3600,
             'nbf' => Time.now.to_i - 60,
             'iat' => Time.now.to_i,
             'aud' => 'appid',
-            'iss' => 'fake.google.com'
+            'iss' => 'accounts.google.com'
           }
-        end
-        let(:id_token) { JWT.encode(token_info, 'secret') }
+        id_token = JWT.encode(token_info, 'secret')
         let(:access_token) { OAuth2::AccessToken.from_hash(client, 'id_token' => id_token) }
 
-        it 'raises JWT::InvalidIssuerError' do
-          expect { subject.extra }.to raise_error(JWT::InvalidIssuerError)
+        it 'should include id_token when set on the access_token' do
+          expect(subject.extra).to include(id_token: id_token)
+        end
+
+        it 'should include id_info when id_token is set on the access_token and skip_jwt is false' do
+          subject.options[:skip_jwt] = false
+          expect(subject.extra).to include(id_info: token_info)
+        end
+
+        it 'should not include id_info when id_token is set on the access_token and skip_jwt is true' do
+          subject.options[:skip_jwt] = true
+          expect(subject.extra).not_to have_key(:id_info)
+        end
+
+        it 'should include id_info when id_token is set on the access_token by default' do
+          expect(subject.extra).to include(id_info: token_info)
         end
       end
 
@@ -559,6 +534,37 @@ describe OmniAuth::Strategies::GoogleOauth2 do
       expect(subject).to receive(:client).and_return(client)
       expect(auth_code).to receive(:get_token).with('valid_code', { redirect_uri: 'redirect_uri_without_query_string' }, {})
       subject.build_access_token
+    end
+  end
+
+  describe 'verify_iss option' do
+    before(:each) do
+      subject.options.client_options[:connection_build] = proc do |builder|
+        builder.request :url_encoded
+        builder.adapter :test do |stub|
+          stub.get('/oauth2/v3/tokeninfo?access_token=invalid_iss_token') do
+            [200, { 'Content-Type' => 'application/json; charset=UTF-8' },
+             JSON.dump(
+               aud: '000000000000.apps.googleusercontent.com',
+               sub: '123456789',
+               email_verified: 'true',
+               email: 'example@example.com',
+               access_type: 'offline',
+               scope: 'profile email',
+               expires_in: 436,
+               iss: 'foobar.com'
+             )]
+          end
+        end
+      end
+      subject.options.authorized_client_ids = ['000000000000.apps.googleusercontent.com']
+      subject.options.client_id = '000000000000.apps.googleusercontent.com'
+      subject.options[:verify_iss] = false
+    end
+
+    it 'should verify token if the iss does not match options.expected_iss' do
+      result = subject.send(:verify_token, 'invalid_iss_token')
+      expect(result).to eq(true)
     end
   end
 


### PR DESCRIPTION
revert all changes up to `e3cbdc512a020249e201300df01ed4ddde78d176` (Switch to using `userinfo` instead of G+ `plus.me` endpoint)

